### PR TITLE
add up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
 # SCE Development Environment
 To work on any of the SCE projects, clone this repository and run
  `python3 sce.py setup`.
+
+## Available Commands
+### Setup
+This will clone and setup [SCE-RPC](https://github.com/SCE-Development/SCE-RPC/),
+ [Core-v4](https://github.com/SCE-Development/Core-v4/) and 
+ [SCE-discord-bot](https://github.com/SCE-Development/SCE-discord-bot).
+ This command can be run with `python3 sce.py setup` for MacOS/Linux or `py sce.py setup` for Windows.
+
+The tool will automatically create a `sce` command which you can run from anywhere.
+
+**Note:** For windows users, you will be prompted to add this to your path for the `sce` command.
+![image](https://user-images.githubusercontent.com/36345325/89665917-4acb1400-d88e-11ea-97d8-1ace95b5741f.png)
+
+
+### Presubmit
+This tool runs presubmit checks for a project. For example:
+```sh
+# To run tests on all projects
+sce presubmit
+# To run a test on SCE-RPC
+sce presubmit --project SCE-RPC
+# To run a test on SCE-RPC and Core-v4
+sce presubmit --project SCE-RPC Core-v4
+```
+
+### Run
+This command will run a number of services for development. The available commands are:
+```sh
+# runs everything
+sce run
+# runs the core-v4 frontend
+sce run frontend
+# runs the core-4 backend server
+sce run server
+# runs the led sign python rpc server
+sce run led-sign
+# runs the 2d printing python rpc server
+sce run 2d-printing
+# runs the 3d printing python rpc server
+sce run 3d-printing
+# runs the discord bot project
+sce run discord
+# runs the sce-rpc project
+sce run sce-rpc
+# runs the core-v4 project
+sce run core-v4
+# runs mongod
+sce run mongo
+```
+**Note:** you can run multiple services at once e.g. `npm run discord server`
+

--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ sce run mongo
 ```
 **Note:** you can run multiple services at once e.g. `npm run discord server`
 
+### Generate
+We can have the `sce` toolg generate gRPC code for us.
+```
+sce generate <path to proto> --language <language types>
+```
+So far, supported langage types are `js` and `py`.
+
+### Rebuild
+This is for Windows users only, who need to rebuild their `.exe` file for the
+ `sce` command to work.
+```
+sce rebuild
+```
+

--- a/sce.py
+++ b/sce.py
@@ -1,6 +1,9 @@
 import argparse
+import platform
+import os
 from tools.setup import SceSetupTool
 from tools.sce_proto_generator import SceProtoGenerator
+from tools.sce_service_handler import SceServiceHandler
 from tools.sce_presubmit_handler import ScePresubmitHandler
 
 parser = argparse.ArgumentParser()
@@ -17,8 +20,15 @@ parser.add_argument(
     help='The language(s) to generate proto code.')
 parser.add_argument(
     '--service', '-s', nargs='*',
-    help='Docker Container Name')
+    help='SCE Service name')
 args = parser.parse_args()
+
+# cd into the dev folder if we are in windows.
+# we dont need to do it for unix/macos because
+# changing the directory is part of the sce alias.
+if platform.system() == "Windows":
+    place = os.environ["SCE_PATH"]
+    os.chdir(place)
 
 if args.command == 'setup':
     setup = SceSetupTool()
@@ -29,6 +39,9 @@ elif args.command == 'presubmit':
 elif args.command == 'generate':
     generator = SceProtoGenerator(args.proto[0], args.language)
     generator.handle_proto_generation()
+elif args.command == 'run':
+    handler = SceServiceHandler(args.service)
+    handler.run_services()
 elif args.command == 'test':
     setup = SceSetupTool()
     setup.add_sce_alias()

--- a/sce.py
+++ b/sce.py
@@ -15,6 +15,8 @@ parser.add_argument(
 parser.add_argument(
     '--language', nargs='+',
     help='The language(s) to generate proto code.')
+parser.add_argument('-s', '--service', nargs='*',
+                    help='Docker Container Name')
 args = parser.parse_args()
 
 if args.command == 'setup':

--- a/sce.py
+++ b/sce.py
@@ -15,8 +15,9 @@ parser.add_argument(
 parser.add_argument(
     '--language', nargs='+',
     help='The language(s) to generate proto code.')
-parser.add_argument('-s', '--service', nargs='*',
-                    help='Docker Container Name')
+parser.add_argument(
+    '--service', '-s', nargs='*',
+    help='Docker Container Name')
 args = parser.parse_args()
 
 if args.command == 'setup':

--- a/tools/sce_docker_handler.py
+++ b/tools/sce_docker_handler.py
@@ -3,27 +3,71 @@ import subprocess
 
 
 class SceDockerHandler:
-
     container_dict = {
-        'frontend': 'docker build Core-v4/. -t frontend && docker run -p 3000:80 frontend',
-        'mongo': ' docker run -p 27017:27017 mongo',
-        'led-sign': 'docker build /SCE-RPC/server/led_sign/. -t led-sign && docker run -p 5000:50051 led-sign',
-        '2d-printing': 'docker build /SCE-RPC/server/printing/. -t 2d-printing && docker run -p 5001:50051 2d-printing',
-        '3d-printing': 'docker build /SCE-RPC/server/printing_3d/. -t 3d-printing && docker run -p 5002:50051 3d-printing',
-        'api': 'docker build Core-v4/api/. -t api && docker run -p 8080:8080 api',
-        'logging': 'docker build Core-v4/api/logging/. -t logging && docker run -p 8081:8081 logging',
-        'mailer': 'docker build Core-v4/api/mailer/Dockerfile -t mailer && docker run -p 8082:8082 mailer',
-        'core-v4': 'cd Core-v4 && docker-compose up'
+        'frontend': 'cd Core-v4 && npm run frontend',
+        'server': 'cd Core-v4 && npm run server',
+        'led-sign': 'cd SCE-RPC/server/led_sign/ && python3 led_sign_server.py',
+        '2d-printing': 'cd SCE-RPC/server/printing/ && python3 printing_server.py',
+        '3d-printing': 'cd SCE-RPC/server/printing_3d/ && python3 print_3d_server.py',
+        'main_endpoints': 'cd Core-v4/api && npm run main_endpoints',
+        'logging': 'cd Core-v4/api && npm run logging',
+        'google_api': 'cd Core-v4/api && npm run google_api',
+        'discord-bot': True,
+        'sce-rpc': True,
+        'core-v4': True,
+        'mongo': True,
     }
 
-    def run_services(self, services=None):
-        print(services)
+    def __init__(self, services):
+        self.services = services
 
-        if services == None:
-            print("Mate, we are going to run everything")  # NEVER DELETE
+    def run_services(self):
+        if not self.services:
+            self.all_systems_go()
         else:
-            for service in services:
-                if service not in self.container_dict:
-                    print("GO TO HELL MATE!!")
+            for service in self.services:
+                if service == 'print':
+                    print('Available Services (case sensitive):')
+                    for key in self.container_dict:
+                        print('\t', key)
+                elif service not in self.container_dict:
+                    print(
+                        f"{service} does not exist. If you would like to see the list of available services type: run -s print")
+                elif service == "sce-rpc":
+                    self.run_sce_rpc()
+                elif service == 'core-v4':
+                    self.run_core_v4()
+                elif service == 'discord-bot':
+                    self.run_discord_bot()
+                elif service == 'mongo':
+                    self.run_mongodb()
                 else:
                     subprocess.run(self.container_dict[service])
+
+    def run_mongodb(self):
+        if os.path.exists('~/data/db'):
+            subprocess.run('mongod --dbpath ~/data/db')
+        else:
+            subprocess.run('mongod')
+
+    def run_core_v4(self):
+        # self.run_mongodb()
+        subprocess.Popen(self.container_dict['frontend'], shell=True)
+        subprocess.Popen(self.container_dict['server'], shell=True)
+
+    def run_sce_rpc(self):
+
+        subprocess.Popen('python3 led_sign_server.py',
+                         cwd='SCE-RPC/server/led_sign/',
+                         shell=True)
+        # subprocess.Popen(self.container_dict['3d-printing'], shell=True)
+        # subprocess.Popen(self.container_dict['2d-printing'], shell=True)
+        subprocess.Popen('npm start', cwd='SCE-RPC', shell=True)
+
+    def run_discord_bot(self):
+        subprocess.Popen('npm start', cwd='SCE-discord-bot/', shell=True)
+
+    def all_systems_go(self):
+        self.run_sce_rpc()
+        self.run_core_v4()
+        self.run_discord_bot()

--- a/tools/sce_docker_handler.py
+++ b/tools/sce_docker_handler.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import platform
 
 
 class SceDockerHandler:
@@ -19,7 +20,23 @@ class SceDockerHandler:
     }
 
     def __init__(self, services):
+        self.user_os = platform.system()
+        self.py_command = "py" if self.user_os == "Windows" else "python3"
         self.services = services
+        self.service_dict = {
+            'frontend': 'cd Core-v4 && npm start',
+            'server': 'cd Core-v4 && npm run server',
+            'led-sign': f'cd SCE-RPC/server/led_sign/ && \
+                {self.py_command} led_sign_server.py',
+            '2d-printing': f'cd SCE-RPC/server/printing/ && \
+                {self.py_command} printing_server.py',
+            '3d-printing': f'cd SCE-RPC/server/printing_3d/ && \
+                {self.py_command} print_3d_server.py',
+            'discord': True,
+            'sce-rpc': True,
+            'core-v4': True,
+            'mongo': True,
+        }
 
     def run_services(self):
         if not self.services:
@@ -28,14 +45,15 @@ class SceDockerHandler:
             for service in self.services:
                 if service == 'print':
                     self.print_usage()
-                elif service not in self.container_dict:
+                elif service not in self.service_dict:
                     print(
-                        f"{service} does not exist. If you would like to see the list of available services type: run -s print")
+                        f"{service} does not exist. Avaliable services are:",
+                        [item for item in list(self.service_dict.keys())])
                 elif service == "sce-rpc":
                     self.run_sce_rpc()
                 elif service == 'core-v4':
                     self.run_core_v4()
-                elif service == 'discord-bot':
+                elif service == 'discord':
                     self.run_discord_bot()
                 elif service == 'mongo':
                     self.run_mongodb()
@@ -44,7 +62,7 @@ class SceDockerHandler:
 
     def print_usage(self):
         print('Available Services (case sensitive):')
-        for key in self.container_dict:
+        for key in self.service_dict:
             print('\t', key)
 
     def run_mongodb(self):
@@ -68,7 +86,7 @@ class SceDockerHandler:
         subprocess.Popen('npm start', cwd='SCE-RPC', shell=True)
 
     def run_discord_bot(self):
-        subprocess.Popen('npm start', cwd='SCE-discord-bot/', shell=True)
+        subprocess.Popen('cd SCE-discord-bot && npm start', shell=True)
 
     def all_systems_go(self):
         self.run_sce_rpc()

--- a/tools/sce_docker_handler.py
+++ b/tools/sce_docker_handler.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+
+
+class SceDockerHandler:
+
+    container_dict = {
+        'frontend': 'docker build Core-v4/. -t frontend && docker run -p 3000:80 frontend',
+        'mongo': ' docker run -p 27017:27017 mongo',
+        'led-sign': 'docker build /SCE-RPC/server/led_sign/. -t led-sign && docker run -p 5000:50051 led-sign',
+        '2d-printing': 'docker build /SCE-RPC/server/printing/. -t 2d-printing && docker run -p 5001:50051 2d-printing',
+        '3d-printing': 'docker build /SCE-RPC/server/printing_3d/. -t 3d-printing && docker run -p 5002:50051 3d-printing',
+        'api': 'docker build Core-v4/api/. -t api && docker run -p 8080:8080 api',
+        'logging': 'docker build Core-v4/api/logging/. -t logging && docker run -p 8081:8081 logging',
+        'mailer': 'docker build Core-v4/api/mailer/Dockerfile -t mailer && docker run -p 8082:8082 mailer',
+        'core-v4': 'cd Core-v4 && docker-compose up'
+    }
+
+    def run_services(self, services=None):
+        print(services)
+
+        if services == None:
+            print("Mate, we are going to run everything")  # NEVER DELETE
+        else:
+            for service in services:
+                if service not in self.container_dict:
+                    print("GO TO HELL MATE!!")
+                else:
+                    subprocess.run(self.container_dict[service])

--- a/tools/sce_docker_handler.py
+++ b/tools/sce_docker_handler.py
@@ -27,9 +27,7 @@ class SceDockerHandler:
         else:
             for service in self.services:
                 if service == 'print':
-                    print('Available Services (case sensitive):')
-                    for key in self.container_dict:
-                        print('\t', key)
+                    self.print_usage()
                 elif service not in self.container_dict:
                     print(
                         f"{service} does not exist. If you would like to see the list of available services type: run -s print")
@@ -43,6 +41,11 @@ class SceDockerHandler:
                     self.run_mongodb()
                 else:
                     subprocess.run(self.container_dict[service])
+
+    def print_usage(self):
+        print('Available Services (case sensitive):')
+        for key in self.container_dict:
+            print('\t', key)
 
     def run_mongodb(self):
         if os.path.exists('~/data/db'):

--- a/tools/sce_presubmit_handler.py
+++ b/tools/sce_presubmit_handler.py
@@ -58,9 +58,6 @@ class ScePresubmitHandler:
             self.print_usage()
             return
         print('\nRunning tests for: ' + project)
-        if platform.system() == "Windows":
-            place = os.environ["SCE_PATH"]
-            os.chdir(place)
         if project != 'dev':
             os.chdir(project)
         project_tests = self.test_commands[project]

--- a/tools/sce_service_handler.py
+++ b/tools/sce_service_handler.py
@@ -3,22 +3,7 @@ import subprocess
 import platform
 
 
-class SceDockerHandler:
-    container_dict = {
-        'frontend': 'cd Core-v4 && npm run frontend',
-        'server': 'cd Core-v4 && npm run server',
-        'led-sign': 'cd SCE-RPC/server/led_sign/ && python3 led_sign_server.py',
-        '2d-printing': 'cd SCE-RPC/server/printing/ && python3 printing_server.py',
-        '3d-printing': 'cd SCE-RPC/server/printing_3d/ && python3 print_3d_server.py',
-        'main_endpoints': 'cd Core-v4/api && npm run main_endpoints',
-        'logging': 'cd Core-v4/api && npm run logging',
-        'google_api': 'cd Core-v4/api && npm run google_api',
-        'discord-bot': True,
-        'sce-rpc': True,
-        'core-v4': True,
-        'mongo': True,
-    }
-
+class SceServiceHandler:
     def __init__(self, services):
         self.user_os = platform.system()
         self.py_command = "py" if self.user_os == "Windows" else "python3"
@@ -40,6 +25,7 @@ class SceDockerHandler:
 
     def run_services(self):
         if not self.services:
+            print('damn')
             self.all_systems_go()
         else:
             for service in self.services:
@@ -58,7 +44,8 @@ class SceDockerHandler:
                 elif service == 'mongo':
                     self.run_mongodb()
                 else:
-                    subprocess.run(self.container_dict[service])
+                    subprocess.check_call(self.service_dict[service],
+                                          shell=True)
 
     def print_usage(self):
         print('Available Services (case sensitive):')
@@ -67,22 +54,19 @@ class SceDockerHandler:
 
     def run_mongodb(self):
         if os.path.exists('~/data/db'):
-            subprocess.run('mongod --dbpath ~/data/db')
+            subprocess.Popen('mongod --dbpath ~/data/db')
         else:
-            subprocess.run('mongod')
+            subprocess.Popen('mongod')
 
     def run_core_v4(self):
-        # self.run_mongodb()
-        subprocess.Popen(self.container_dict['frontend'], shell=True)
-        subprocess.Popen(self.container_dict['server'], shell=True)
+        self.run_mongodb()
+        subprocess.Popen(self.service_dict['frontend'], shell=True)
+        subprocess.Popen(self.service_dict['server'], shell=True)
 
     def run_sce_rpc(self):
-
-        subprocess.Popen('python3 led_sign_server.py',
-                         cwd='SCE-RPC/server/led_sign/',
-                         shell=True)
-        # subprocess.Popen(self.container_dict['3d-printing'], shell=True)
-        # subprocess.Popen(self.container_dict['2d-printing'], shell=True)
+        subprocess.Popen(self.service_dict['led-sign'], shell=True)
+        subprocess.Popen(self.service_dict['3d-printing'], shell=True)
+        subprocess.Popen(self.service_dict['2d-printing'], shell=True)
         subprocess.Popen('npm start', cwd='SCE-RPC', shell=True)
 
     def run_discord_bot(self):

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -133,7 +133,7 @@ in your Path environment variable.
     def add_sce_alias(self):
         if self.operating == "Windows":
             self.add_alias_windows()
-        elif self.operating == "Linux" and self.operating == "Darwin":
+        elif self.operating == "Linux" or self.operating == "Darwin":
             self.add_alias_unix()
 
     def setup_core_v4(self):


### PR DESCRIPTION
We can now run the various parts of our project with the `sce` command.

## How to test this PR
1. Make sure you ran setup (windows users paste the value into your PATH after running `py sce.py setup`)
1. Run various services we offer and ensure they work, a mapping is below:
```
sce run frontend: runs the core-v4 frontend
sce run server: runs the core-4 backend server
sce run led-sign: runs the led sign python rpc server
sce run 2d-printing: runs the 2d printing python rpc server
sce run 3d-printing: runs the 3d printing python rpc server
sce run discord: runs the discord bot project
sce run sce-rpc: runs the sce-rpc project
sce run core-v4: runs the core-v4 project
sce run mongo: runs mongodb
```